### PR TITLE
Update readme with links and more info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # OpenRCT2-OpenScenarios
 
 [![Join the chat at https://gitter.im/PFCKrutonium/OpenRCT2-OpenScenarios](https://badges.gitter.im/PFCKrutonium/OpenRCT2-OpenScenarios.svg)](https://gitter.im/PFCKrutonium/OpenRCT2-OpenScenarios?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)  
-Replacement Scenarios and Campaign for the Scenarios that came with RCT2 Originally.
+Replacement Scenarios and Campaign for the Scenarios that came with RCT2 Originally. The goal is to create a campaign of +/- 30 scenarios with a good difficulty curve like in RCT1.
 
 Contribution and Approval process is not yet complete, but feel free to open PR's with Scenarios.
+
+### LINKS
+[Scenario list](https://docs.google.com/spreadsheets/d/1O1EUbyu-bKUSXxEBr6QElx7yqRPqFXEzIg_jN-_HxkY/edit?usp=drivesdk)
+[Open scenraios outline](https://docs.google.com/document/d/1WO3QtQM9upL0BqET3GBX7mkPofqFXxbBkBjD1snwjqE/edit?usp=drivesdk)
 
 ### REQUIREMENTS TO SUBMIT A SCENARIO:
 
@@ -14,7 +18,12 @@ Contribution and Approval process is not yet complete, but feel free to open PR'
 4. Should include a Description of the Scenario, and mention what difficulty category it is
 5. Should have at least 1 person that is not the scenario creator play test it and verify that the scenario has no major issues, and that the difficulty is set correctly.
 
-## Of Note: Custom Scenery Objects are Allowed, so long as their author authorizes it.
+### SCENARIO DESIGN GUIDELINES:
+
+- The scenario must be able to be completed in a convenient way. This means without using cheats or massively exploiting game mechanics (like microcoasters).
+- Using cheats to create the scenario is acceptable as long as the park is reproducible without cheats, thus no usage of zero clearance or tile inspector for example.
+- Also no rides outside park boundaries, trackitecture or hacked rides.
+- Only use objects (rides, scenery, paths, terrain ...) labeled with _RCT2_ or _OpenRCT2 Official_, so no RCT1-exclusive or custom objects, or from the expansions (WW/TT).
 
 ### HOW TO CONTRIBUTE:
 
@@ -22,9 +31,9 @@ If you know how, make a PR with the files in the correct locations. If not, then
 
 Thanks for taking the time to Contribute!
 
-Please Note: There is exceptions for Parks that existed _before_ this project existed, and the original source files have been lost. In all such cases, the original owner has given permission for them to be used. IF YOUR PARK HAS BEEN USED WITHOUT YOUR PERMISSION, PLEASE CONTACT ME, THIS WAS NOT ON PURPOSE. 
+Please Note: There are exceptions for Parks that existed _before_ this project existed, and the original source files have been lost. In all such cases, the original owner has given permission for them to be used. IF YOUR PARK HAS BEEN USED WITHOUT YOUR PERMISSION, PLEASE CONTACT ME, THIS WAS NOT ON PURPOSE. 
 
-# People who have contributed Parks:
+## People who have contributed Parks:
 * maian_sos  
 * Keatzee 
 * Xedoh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Contribution and Approval process is not yet complete, but feel free to open PR'
 
 ### LINKS
 [Scenario list](https://docs.google.com/spreadsheets/d/1O1EUbyu-bKUSXxEBr6QElx7yqRPqFXEzIg_jN-_HxkY/edit?usp=drivesdk)
-[Open scenraios outline](https://docs.google.com/document/d/1WO3QtQM9upL0BqET3GBX7mkPofqFXxbBkBjD1snwjqE/edit?usp=drivesdk)
+
+[Open scenarios outline](https://docs.google.com/document/d/1WO3QtQM9upL0BqET3GBX7mkPofqFXxbBkBjD1snwjqE/edit?usp=drivesdk)
 
 ### REQUIREMENTS TO SUBMIT A SCENARIO:
 


### PR DESCRIPTION
I added some info which is frequently asked for in the discord channel:
- goal of the project
- scenario design guidelines
- links to shared google docs that can't be pinned in discord

TO DO: chat link still links to Gitter. Needs to be updated to Discord. I don't know how to do that.